### PR TITLE
arch: Add macos arm64 neon instructions

### DIFF
--- a/libpng.lua
+++ b/libpng.lua
@@ -121,6 +121,12 @@ if (_PLATFORM_LINUX) then
 end
 
 if (_PLATFORM_MACOS) then
+  configuration { "ARM64" }
+
+  files { neon_files }
+
+  configuration { "x64" }
+
   defines { sse_defines }
 
   files { sse_files }


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/1000

Allows macOS arm64 to build as it needs neon intrinsics and cannot use intel intrinsics