### PR TITLE
Cleanup unneeded defines

### DIFF
--- a/libpng.lua
+++ b/libpng.lua
@@ -13,7 +13,16 @@ includedirs {
   _3RDPARTY_DIR .. "/zlib",
 }
 
+defines {
+  "PNG_INTEL_SSE", -- allow libpng to use intel intrinsics if they're available
+}
+
 files {
+  "arm/arm_init.c",
+  "arm/palette_neon_intrinsics.c",
+  "arm/filter_neon_intrinsics.c",
+  "intel/filter_sse2_intrinsics.c",
+  "intel/intel_init.c",
   "png.c",
   "pngerror.c",
   "pngget.c",
@@ -31,116 +40,20 @@ files {
   "pngwutil.c",
 }
 
-sse_defines = {
-  "PNG_INTEL_SSE",
-}
-
-sse_files = {
-  "intel/filter_sse2_intrinsics.c",
-  "intel/intel_init.c",
-}
-
-neon_files = {
-  "arm/arm_init.c",
-  "arm/palette_neon_intrinsics.c",
-  "arm/filter_neon_intrinsics.c",
-}
-
 if (_PLATFORM_ANDROID) then
-  defines {
-    "HAVE_MEMMOVE",
-  }
-
-  configuration { "*arm64*" }
-
-  files { neon_files }
-
-  configuration { "*armv7*" }
-
-  files { neon_files }
-
-  configuration { "*x64*" }
-
-  defines { sse_defines }
-
-  files { sse_files }
-
-  configuration { "*x86*" }
-
-  defines { sse_defines }
-
-  files { sse_files }
-end
-
-if (_PLATFORM_COCOA) then
-  defines {
-    "_REENTRANT",
-    "NATIVECOMPILE",
-  }
-
-  configuration { "*arm64*" }
-
-  files { neon_files }
-
-  configuration { "*x64*" }
-
-  defines { sse_defines }
-
-  files { sse_files }
 end
 
 if (_PLATFORM_IOS) then
-  defines {
-    "_REENTRANT",
-    "NATIVECOMPILE",
-  }
-
-  configuration { "*arm64*" }
-
-  files { neon_files }
-
-  configuration { "*x64*" }
-
-  defines { sse_defines }
-
-  files { sse_files }
 end
 
 if (_PLATFORM_LINUX) then
-  configuration { "ARM64" }
-
-  defines {
-    "PNG_ARM_NEON_OPT=0", -- turn off neon instructions as they're not supported for linux arm64
-  }
-
-  configuration { "x64" }
-
-  defines { sse_defines }
-
-  files { sse_files }
 end
 
 if (_PLATFORM_MACOS) then
-  configuration { "ARM64" }
-
-  files { neon_files }
-
-  configuration { "x64" }
-
-  defines { sse_defines }
-
-  files { sse_files }
 end
 
 if (_PLATFORM_WINDOWS) then
-  defines { sse_defines }
-
-  files { sse_files }
 end
 
 if (_PLATFORM_WINUWP) then
-  defines {
-    "_CRT_SECURE_NO_WARNINGS",
-    "PNG_ARM_NEON_OPT=0", -- WinUWP doesn't support conditional files or neon
-  }
 end


### PR DESCRIPTION
Issue-number: https://devtopia.esri.com/runtime/devops/issues/1774

libpng does compiler time checks for intrinsics so there's no longer a
need to specify which platform builds which object.